### PR TITLE
Fix SigmaProfession compatibility nr2

### DIFF
--- a/ATT-Classic.lua
+++ b/ATT-Classic.lua
@@ -11136,7 +11136,7 @@ app:GetWindow("Tradeskills", UIParent, function(self, ...)
 							
 							if craftType ~= "none" then
 								-- Attempt to harvest the item associated with this craft.
-								NPCHarvester:SetCraftSpell(craftIndex);
+								GameTooltip.SetCraftSpell(NPCHarvester, craftIndex);
 								local link, craftedItemID = select(2, NPCHarvester:GetItem());
 								if link then craftedItemID = GetItemInfoInstant(link); end
 								


### PR DESCRIPTION
hi there, there are still some errors from this file, I dug around to see what was causing the issues and the problem line is this:

https://github.com/DFortun81/ATT-TBC-Classic/blob/master/ATT-Classic.lua#L11139

the issue is that my addon creates a new order of "craftIndex" / "skillIndex" so that the recipes can be shown in a different way in the frame.

so when you use "GetNumCrafts()" or "GetNumTradeSkills()" that function returns the new number of crafts/skills.

when for some reason the new number is higher than the blizz value, calling SetCraftSpell will eventually result in an error because you are trying to set a craftIndex of a craft that does not exist for the user as far as blizz original functions are concerned.

for this reason I had to replace the blizz GameTooltip.SetCraftFrame function with one defined by my addon that would correctly handle the indexes.

when you clone GameTooltip you get the original version of SetCraftFrame, so this pull request changes the line to use the function from the GameTooltip rather than using the function from your clone.

regardless, the changes will be applied to your clone because the first parameter is the object that will be changed (your clone)

however I would also like to point out that the current setup doesn't really work as far as I can tell.

the "link" and the "craftedItemID" that you try to get at the lines:
https://github.com/DFortun81/ATT-TBC-Classic/blob/master/ATT-Classic.lua#L11140-L11141

always return "nil" in my tests, even when I only load your addon and not mine.